### PR TITLE
Ignore tests with the `CanBlockIsFalse` flag

### DIFF
--- a/expectations.json
+++ b/expectations.json
@@ -288,7 +288,6 @@
       },
       "wait": {
         "bigint": {
-          "cannot-suspend-throws.js": false,
           "false-for-timeout-agent.js": false,
           "nan-for-timeout.js": false,
           "negative-timeout-agent.js": false,
@@ -307,7 +306,6 @@
           "waiterlist-order-of-operations-is-fifo.js": false,
           "was-woken-before-timeout.js": false
         },
-        "cannot-suspend-throws.js": false,
         "false-for-timeout-agent.js": false,
         "good-views.js": false,
         "nan-for-timeout.js": false,

--- a/runner.ts
+++ b/runner.ts
@@ -101,7 +101,8 @@ async function processTest(
   const features = frontMatter.features ?? [];
   const flags = frontMatter.flags ?? [];
 
-  const ignore = features.includes("IsHTMLDDA");
+  const ignore = features.includes("IsHTMLDDA") ||
+    flags.includes("CanBlockIsFalse");
   if (ignore) {
     let testName = test;
     if (typeof expected === "string") {


### PR DESCRIPTION
Deno is a JS execution environment which can block, unlike a browser's main thread, and so tests with the `CanBlockIsFalse` flag will fail. This change ignores those tests.
