### PR TITLE
Use the `$GITHUB_PATH` file for making Deno available in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           DENO_VERSION="$(cat DENO_VERSION)"
           curl -fsSL https://deno.land/x/install/install.sh | sh -s "$DENO_VERSION"
-          echo "PATH=$HOME/.deno/bin:$PATH" >> "$GITHUB_ENV"
+          echo "$HOME/.deno/bin" >> "$GITHUB_PATH"
 
       - name: Check the expectations file is sorted
         run: ./scripts/sort_expectations.ts --check

--- a/.github/workflows/update-deno.yml
+++ b/.github/workflows/update-deno.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           DENO_VERSION="$(cat DENO_VERSION)"
           curl -fsSL https://deno.land/x/install/install.sh | sh -s "$DENO_VERSION"
-          echo "PATH=$HOME/.deno/bin:$PATH" >> "$GITHUB_ENV"
+          echo "$HOME/.deno/bin" >> "$GITHUB_PATH"
 
       - name: Update if needed
         id: update

--- a/.github/workflows/update-test262.yml
+++ b/.github/workflows/update-test262.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           DENO_VERSION="$(cat DENO_VERSION)"
           curl -fsSL https://deno.land/x/install/install.sh | sh -s "$DENO_VERSION"
-          echo "PATH=$HOME/.deno/bin:$PATH" >> "$GITHUB_ENV"
+          echo "$HOME/.deno/bin" >> "$GITHUB_PATH"
 
       - name: Update and commit
         id: run


### PR DESCRIPTION
This will hopefully fix the failure in https://github.com/andreubotella/deno_test262/actions/runs/1180412403 for good.
