### PR TITLE
Don't use `git pull` when updating the harness

### DIFF
--- a/.github/workflows/update-test262.yml
+++ b/.github/workflows/update-test262.yml
@@ -29,7 +29,8 @@ jobs:
         run: |
           cd test262
           OLD_SHA="$(git rev-parse HEAD)"
-          git pull
+          git fetch
+          git reset --hard origin/main
           NEW_SHA="$(git rev-parse HEAD)"
           cd ..
           if [ "$OLD_SHA" != "$NEW_SHA" ]; then


### PR DESCRIPTION
Fixes this CI failure: https://github.com/andreubotella/deno_test262/runs/3520162324
