### PR TITLE
Make sure the update CI jobs can be triggered manually

### DIFF
--- a/.github/workflows/update-deno.yml
+++ b/.github/workflows/update-deno.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Every day at 12 AM UTC.
     - cron: 0 0 * * *
+  workflow_dispatch:
 
 jobs:
   update-deno:

--- a/.github/workflows/update-test262.yml
+++ b/.github/workflows/update-test262.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Every Monday at 12 AM UTC.
     - cron: 0 0 * * 1
+  workflow_dispatch:
 
 jobs:
   update-test262:


### PR DESCRIPTION
This would help debugging issues, and would make it possible to update the test262 test suite outside of the schedule if needed.
