### PR TITLE
The CI update jobs need the `GITHUB_TOKEN` envvar

### DIFF
--- a/.github/workflows/update-deno.yml
+++ b/.github/workflows/update-deno.yml
@@ -54,3 +54,5 @@ jobs:
 
           gh pr create --fill --draft --label update-deno \
             --assignee andreubotella --reviewer andreubotella
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-test262.yml
+++ b/.github/workflows/update-test262.yml
@@ -49,3 +49,5 @@ jobs:
             gh pr create --fill --draft --label update-test262 \
               --assignee andreubotella --reviewer andreubotella
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the CI failure at https://github.com/andreubotella/deno_test262/runs/3527558938
