### PR TITLE
Use the bot Personal Access Token to checkout the repo in update CI jobs

### DIFF
--- a/.github/workflows/update-deno.yml
+++ b/.github/workflows/update-deno.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.BOT_GH_TOKEN }}
           submodules: recursive
 
       - name: Setup Deno (previous version)
@@ -45,10 +46,8 @@ jobs:
       - name: Commit update
         if: ${{ steps.update.outputs.updated == 'true' }}
         run: |
-          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import
           git config --global user.email "90636620+andreubot@users.noreply.github.com"
           git config --global user.name "andreubot"
-          git config --global user.signingkey "1D165DD908A9C331"
 
           BRANCH_NAME="update-deno/$(cat ./DENO_VERSION)"
           PR_TITLE="Update Deno to $(cat ./DENO_VERSION)"
@@ -60,6 +59,4 @@ jobs:
           gh pr create --title "$PR_TITLE" --body "" --draft \
             --assignee andreubotella --label update-deno
         env:
-          GH_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
-          GPG_SIGNING_KEY: ${{ secrets.BOT_GPG_SIGNING_KEY }}

--- a/.github/workflows/update-test262.yml
+++ b/.github/workflows/update-test262.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.BOT_GH_TOKEN }}
           submodules: recursive
 
       # Needed to run ./scripts/cleanup_expectations.ts
@@ -27,10 +28,8 @@ jobs:
 
       - name: Update and commit
         run: |
-          echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --import
           git config --global user.email "90636620+andreubot@users.noreply.github.com"
           git config --global user.name "andreubot"
-          git config --global user.signingkey "1D165DD908A9C331"
 
           cd test262
           OLD_SHA="$(git rev-parse HEAD)"
@@ -55,6 +54,4 @@ jobs:
               --assignee andreubotella --label update-test262
           fi
         env:
-          GH_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
-          GPG_SIGNING_KEY: ${{ secrets.BOT_GPG_SIGNING_KEY }}


### PR DESCRIPTION
This was keeping PRs opened by CI from running the CI jobs (see #48, for example).

This change also removes the GPG signing key, since it's unnecessary given that the PR will be merged from the Github interface.
