### PR TITLE
Don't expose the `console` global to the test environment

### DIFF
--- a/runner_util/setup.js
+++ b/runner_util/setup.js
@@ -2,7 +2,7 @@
   // Make sure we control the only output.
   const { Deno, console, URL } = globalThis;
   delete globalThis.Deno;
-  //delete globalThis.console;
+  delete globalThis.console;
   delete globalThis.URL;
 
   const liftThis = (fn) => fn.call.bind(fn);


### PR DESCRIPTION
This bug was introduced by mistake in #25.
