### PR TITLE
Implement `$262.agent.start()`

### DIFF
--- a/runner.ts
+++ b/runner.ts
@@ -43,6 +43,7 @@ async function runTest(
     cmd: [
       "deno",
       "run",
+      "--unstable",
       "--allow-read",
       "--allow-env",
       fromFileUrl(SETUP_SCRIPT),

--- a/runner_util/agent-setup.js
+++ b/runner_util/agent-setup.js
@@ -1,0 +1,20 @@
+(() => {
+  const { Deno } = globalThis;
+  delete globalThis.Deno;
+  delete globalThis.console;
+  delete globalThis.URL;
+
+  globalThis.$262 = {};
+
+  globalThis.addEventListener("message", (evt) => {
+    const { script, lock } = evt.data;
+
+    Atomics.store(lock, 0, 1);
+    Atomics.notify(lock, 0, 1);
+
+    const err = Deno.core.evalContext(script)[1];
+    if (err !== null) {
+      throw err.thrown;
+    }
+  });
+})();

--- a/runner_util/setup.js
+++ b/runner_util/setup.js
@@ -89,6 +89,20 @@
       }
       return ret;
     },
+    agent: {
+      start(script) {
+        const worker = new Worker(
+          new URL("./agent-setup.js", import.meta.url),
+          { type: "module", deno: true },
+        );
+        const lock = new Int32Array(new SharedArrayBuffer(4));
+        worker.postMessage({
+          script: String(script),
+          lock,
+        });
+        Atomics.wait(lock, 0, 0);
+      },
+    },
   };
 
   const test262Root = new URL("../test262/", import.meta.url);


### PR DESCRIPTION
This will not result in any new test successes, because starting an agent isn't useful by itself – `$262.agent.getReport()` is needed to get any data from the agent.

Closes #30.
