### PR TITLE
Implement `$262.agent.broadcast()`.

### DIFF
--- a/runner_util/agent-setup.js
+++ b/runner_util/agent-setup.js
@@ -4,17 +4,36 @@
   delete globalThis.console;
   delete globalThis.URL;
 
-  globalThis.$262 = {};
+  let broadcastListener = null;
+
+  globalThis.$262 = {
+    agent: {
+      receiveBroadcast(callback) {
+        broadcastListener = callback;
+      },
+    },
+  };
 
   globalThis.addEventListener("message", (evt) => {
-    const { script, lock } = evt.data;
+    if (evt.data.type === "start") {
+      const { script, lock } = evt.data;
 
-    Atomics.store(lock, 0, 1);
-    Atomics.notify(lock, 0, 1);
+      Atomics.store(lock, 0, 1);
+      Atomics.notify(lock, 0, 1);
 
-    const err = Deno.core.evalContext(script)[1];
-    if (err !== null) {
-      throw err.thrown;
+      const err = Deno.core.evalContext(script)[1];
+      if (err !== null) {
+        throw err.thrown;
+      }
+    } else if (evt.data.type === "broadcast") {
+      const { semaphore, sab, number } = evt.data;
+
+      Atomics.add(semaphore, 0, 1);
+      Atomics.notify(semaphore, 0, 1);
+
+      broadcastListener(sab, number);
+    } else {
+      throw new Error(`Unkwnown message received: ${evt.data.type}`);
     }
   });
 })();


### PR DESCRIPTION
Implemented along with `$262.agent.receiveBroadcast()` in the agent's environment.

This will not result in any new test successes, because sending a message to an agent isn't useful by itself – `$262.agent.getReport()` is needed to get any data back.

Closes #55.
